### PR TITLE
remove peer dependency to organic-plasma

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,9 +20,6 @@
     "express": "^4.13.3",
     "less": "^2.5.3"
   },
-  "peerDependencies": {
-    "organic-plasma": "0.0.x"
-  },
   "keywords": [
     "organic",
     "email",


### PR DESCRIPTION
not needed anymore especially with npm 3 + this makes it possible to use the organelle with either  organic-plasma 1.0 (+ feedback) and 0.0.7
